### PR TITLE
Fix toast listener leak and sanitize swatch copy label

### DIFF
--- a/src/components/PaletteSwatch.tsx
+++ b/src/components/PaletteSwatch.tsx
@@ -33,7 +33,7 @@ const PaletteSwatch = ({ hex, label }: PaletteSwatchProps) => {
             <span className="text-muted-foreground text-xs">{label}</span>
           ) : null}
         </div>
-        <Button variant="secondary" size="sm" onClick={copy} aria-label={`Copy ${hex}`}>
+        <Button variant="secondary" size="sm" onClick={copy} aria-label={`Copy ${safeHex}`}>
           Copy
         </Button>
       </div>

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -173,13 +173,14 @@ function useToast() {
 
   React.useEffect(() => {
     listeners.push(setState)
+    setState(memoryState)
     return () => {
       const index = listeners.indexOf(setState)
       if (index > -1) {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent `useToast` from registering duplicate listeners by running effect once
- sync toast state on subscription to avoid stale renders
- ensure PaletteSwatch copy button uses sanitized hex in aria-label

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/hooks/use-toast.ts src/components/PaletteSwatch.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a0b902c02c8321ba163f9cfa4b536f