### PR TITLE
Remove redundant HashRouter wrapper from root render

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <HashRouter>
-      <App />
-    </HashRouter>
-  </React.StrictMode>
+    <App />
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- drop HashRouter import and wrapper from `src/main.tsx`
- rely on `HashRouter` defined in `App.tsx`

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any in several existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68a0be19f5548321accdc91e8e264a67